### PR TITLE
Frontend hardening: auto-refresh, post-confirm Etherscan links, owner-only Withdraw, unified Toast, user token balance

### DIFF
--- a/proofmint-frontend/src/App.tsx
+++ b/proofmint-frontend/src/App.tsx
@@ -5,15 +5,28 @@ import StatePanel from "./components/StatePanel";
 import BuyForm from "./components/BuyForm";
 import Withdraw from "./components/Withdraw";
 import type { WalletState } from "./lib/eth";
+import { BrowserProvider, Signer } from "ethers";
 
 export default function App() {
   const [wallet, setWallet] = useState<WalletState>({
     account: null,
-    chainId: null,
+    chainId: null,          // hex string per WalletState
     provider: null,
   });
 
-  // optional: hydrate if already connected
+  // a simple "poke" to tell StatePanel to refresh after buy/withdraw
+  const [refreshTick, setRefreshTick] = useState(0);
+  const bump = () => setRefreshTick(t => t + 1);
+
+  // adapt ConnectButtons' (signer, chainId:number) to our WalletState
+  const onConnected = async (signer: Signer, chainNum: number) => {
+    const account = await signer.getAddress();
+    const chainIdHex = "0x" + Number(chainNum).toString(16);
+    const provider = new BrowserProvider((window as any).ethereum);
+    setWallet({ account, chainId: chainIdHex, provider });
+  };
+
+  // optional: hydrate if already connected via window.ethereum
   useEffect(() => {
     const eth = (window as any).ethereum;
     if (!eth) return;
@@ -23,10 +36,11 @@ export default function App() {
           eth.request({ method: "eth_accounts" }),
           eth.request({ method: "eth_chainId" }),
         ]);
-        setWallet((w) => ({
+        setWallet(w => ({
           ...w,
           account: accounts?.[0] ?? null,
-          chainId: chainId ?? null,
+          chainId: chainId ?? null, // already hex
+          provider: accounts?.[0] ? new BrowserProvider(eth) : w.provider,
         }));
       } catch {}
     })();
@@ -36,19 +50,27 @@ export default function App() {
     <main className="max-w-3xl mx-auto p-6 space-y-6">
       <header className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Proofmint Demo</h1>
-        <ConnectButtons onConnected={setWallet} />
+        <ConnectButtons onConnected={onConnected} />
       </header>
 
-      {/* Sale state (reads via FALLBACK_RPC or wallet) */}
-      <StatePanel />
+      {/* pass provider/account + refresh signal so we can show userToken */}
+      <StatePanel
+        provider={wallet.provider}
+        account={wallet.account}
+        refreshSignal={refreshTick}
+      />
 
-      {/* Actions (need a connected provider) */}
-      <BuyForm provider={wallet.provider} onPurchased={() => {/* optional: trigger a refresh elsewhere */}} />
-      <Withdraw provider={wallet.provider} onAfterTx={() => {/* optional */}} />
+      {/* Actions */}
+      <BuyForm
+        provider={wallet.provider}
+        onPurchased={bump}             // refresh panel after buy
+      />
+      <Withdraw
+        provider={wallet.provider}
+        onWithdrew={bump}              // refresh panel after withdraw
+      />
 
-      <footer className="text-xs text-gray-500 pt-4">
-        
-      </footer>
+      <footer className="text-xs text-gray-500 pt-4"></footer>
     </main>
   );
 }

--- a/proofmint-frontend/src/components/BuyForm.tsx
+++ b/proofmint-frontend/src/components/BuyForm.tsx
@@ -20,51 +20,59 @@ export default function BuyForm({ provider, onPurchased }: Props) {
 
   const clean = (s: string) => s.replace(",", ".").trim();
 
-  async function onBuy() {
-    try {
-      setBusy(true);
-      setToast(null);
+async function onBuy() {
+  try {
+    setBusy(true);
+    setToast(null);
 
-      if (!provider) throw new Error("Connect a wallet first.");
-      const amt = clean(ethAmount);
-      if (!amt || Number(amt) <= 0) throw new Error("Enter a positive amount.");
+    if (!provider) throw new Error("Connect a wallet first.");
+    const amt = clean(ethAmount);
+    if (!amt || Number(amt) <= 0) throw new Error("Enter a positive amount.");
 
-      // send tx (auto: try direct ETH, fallback to buyTokens())
-      const tx = await buyWithAuto(provider, amt);
+    // send tx (auto: try direct ETH, fallback to buyTokens())
+    const tx = await buyWithAuto(provider, amt);
 
-      // open Etherscan in a new tab immediately
-      const href = `https://sepolia.etherscan.io/tx/${tx.hash}`;
-      window.open(href, "_blank");
+    // show a pending toast, but DON'T open Etherscan yet
+    setToast({
+      kind: "success",
+      text: `Tx sent: ${tx.hash.slice(0, 10)}… (waiting for confirmation)`,
+    });
 
-      // optimistic toast, then confirm
-      setToast({ kind: "success", text: `Tx sent: ${tx.hash.slice(0, 10)}… (opens Etherscan)` });
-      await tx.wait();
-      setToast({ kind: "success", text: `Success: ${tx.hash.slice(0, 10)}…` });
+    // wait for 1 confirmation
+    await tx.wait();
 
-      onPurchased?.();
-    } catch (e: any) {
-      const msg =
-        e?.shortMessage ||
-        e?.info?.error?.message ||
-        e?.cause?.reason ||
-        e?.message ||
-        String(e);
+    // now it's safe to open/link Etherscan
+    const href = `https://sepolia.etherscan.io/tx/${tx.hash}`;
+    setToast({
+      kind: "success",
+      text: `Success: ${tx.hash.slice(0, 10)}… (confirmed)`,
+    });
+    window.open(href, "_blank");
 
-      if (/user rejected|denied/i.test(msg)) {
-        setToast({ kind: "error", text: "Action canceled." });
-      } else if (/insufficient funds/i.test(msg)) {
-        setToast({ kind: "error", text: "Insufficient funds. Top up Sepolia ETH." });
-      } else if (/chain|network|wrong network|unsupported/i.test(msg)) {
-        setToast({ kind: "error", text: "Please switch to Sepolia to continue." });
-      } else if (/amount|value/i.test(msg)) {
-        setToast({ kind: "error", text: "Invalid amount. Try a small positive value (e.g., 0.01)." });
-      } else {
-        setToast({ kind: "error", text: msg });
-      }
-    } finally {
-      setBusy(false);
+    onPurchased?.();
+  } catch (e: any) {
+    const msg =
+      e?.shortMessage ||
+      e?.info?.error?.message ||
+      e?.cause?.reason ||
+      e?.message ||
+      String(e);
+
+    if (/user rejected|denied/i.test(msg)) {
+      setToast({ kind: "error", text: "Action canceled." });
+    } else if (/insufficient funds/i.test(msg)) {
+      setToast({ kind: "error", text: "Insufficient funds. Top up Sepolia ETH." });
+    } else if (/chain|network|wrong network|unsupported/i.test(msg)) {
+      setToast({ kind: "error", text: "Please switch to Sepolia to continue." });
+    } else if (/amount|value/i.test(msg)) {
+      setToast({ kind: "error", text: "Invalid amount. Try a small positive value (e.g., 0.01)." });
+    } else {
+      setToast({ kind: "error", text: msg });
     }
+  } finally {
+    setBusy(false);
   }
+}
 
   return (
     <section className="bg-white rounded-2xl shadow p-5 mb-6">

--- a/proofmint-frontend/src/components/ConnectButtons.tsx
+++ b/proofmint-frontend/src/components/ConnectButtons.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { BrowserProvider, Signer } from "ethers";
-import { CHAIN_ID, CHAIN_ID_HEX, FALLBACK_RPC } from "../env";
+import type { BrowserProvider, Signer } from "ethers";
+import { BrowserProvider as EthersBrowserProvider } from "ethers";
+import { CHAIN_ID, CHAIN_ID_HEX, FALLBACK_RPC, NETWORK } from "../config";
 
 declare global {
   interface Window { ethereum?: any }
@@ -16,30 +17,42 @@ export default function ConnectButtons({
   const [connecting, setConnecting] = useState(false);
   const [address, setAddress] = useState<string | null>(null);
   const [chain, setChain] = useState<number | null>(null);
+  const [err, setErr] = useState<string | null>(null);
 
   const getProvider = () => {
     if (!window.ethereum) throw new Error("No injected wallet found");
-    return new BrowserProvider(window.ethereum);
+    return new EthersBrowserProvider(window.ethereum);
   };
 
   const hydrate = async () => {
-    const provider = getProvider();
-    const accounts: string[] = await provider.send("eth_accounts", []);
-    if (accounts.length === 0) return;
-    const signer = await provider.getSigner();
-    const net = await provider.getNetwork();
-    setAddress((await signer.getAddress()));
-    setChain(Number(net.chainId));
-    onConnected?.(signer, Number(net.chainId));
+    try {
+      setErr(null);
+      const provider = getProvider();
+      // If the site is already approved this returns accounts, otherwise []
+      const accounts: string[] = await provider.send("eth_accounts", []);
+      if (accounts.length === 0) return;
+
+      const signer = await provider.getSigner();
+      const me = await signer.getAddress();
+      const net = await provider.getNetwork();
+
+      setAddress(me);
+      setChain(Number(net.chainId));
+      onConnected?.(signer, Number(net.chainId));
+    } catch (e: any) {
+      setErr(e?.message ?? String(e));
+    }
   };
 
   const connect = async () => {
     setConnecting(true);
+    setErr(null);
     try {
       const provider = getProvider();
       await provider.send("eth_requestAccounts", []);
       await hydrate();
-      // listeners (re-register cleanly)
+
+      // Re-register listeners cleanly
       window.ethereum.removeAllListeners?.("accountsChanged");
       window.ethereum.removeAllListeners?.("chainChanged");
       window.ethereum.removeAllListeners?.("disconnect");
@@ -63,6 +76,10 @@ export default function ConnectButtons({
         setChain(null);
         onDisconnected?.();
       });
+    } catch (e: any) {
+      const m = e?.message ?? String(e);
+      if (/user rejected|denied/i.test(m)) setErr("Connection canceled.");
+      else setErr(m);
     } finally {
       setConnecting(false);
     }
@@ -70,40 +87,44 @@ export default function ConnectButtons({
 
   const switchNetwork = async () => {
     if (!window.ethereum) return;
+    setErr(null);
     try {
       await window.ethereum.request({
         method: "wallet_switchEthereumChain",
         params: [{ chainId: CHAIN_ID_HEX }],
       });
     } catch (err: any) {
-      // If chain is unknown, add it then switch
+      // Unrecognized chain → add then switch
       if (err?.code === 4902) {
         await window.ethereum.request({
           method: "wallet_addEthereumChain",
           params: [{
             chainId: CHAIN_ID_HEX,
-            chainName: CHAIN_ID === 31337 ? "Localhost 8545" : "Sepolia",
+            chainName: NETWORK?.name || "Sepolia",
             nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
-            rpcUrls: [FALLBACK_RPC ?? (CHAIN_ID === 31337 ? "http://127.0.0.1:8545" : "")].filter(Boolean),
-            blockExplorerUrls: [],
+            rpcUrls: [FALLBACK_RPC || (CHAIN_ID === 31337 ? "http://127.0.0.1:8545" : "")].filter(Boolean),
+            blockExplorerUrls: ["https://sepolia.etherscan.io"],
           }],
         });
         await window.ethereum.request({
           method: "wallet_switchEthereumChain",
           params: [{ chainId: CHAIN_ID_HEX }],
         });
+      } else if (err?.code === 4001) {
+        setErr("Network switch canceled.");
       } else {
+        setErr(err?.message ?? String(err));
         console.warn("switchNetwork failed:", err);
       }
     }
   };
 
   useEffect(() => {
-    // auto-hydrate if user already approved this site
     if (window.ethereum) { hydrate().catch(() => {}); }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const short = (a?: string | null) => a ? `${a.slice(0,6)}…${a.slice(-4)}` : "";
+  const short = (a?: string | null) => (a ? `${a.slice(0,6)}…${a.slice(-4)}` : "");
 
   if (!window.ethereum) {
     return <div className="text-sm text-red-600">No injected wallet detected.</div>;
@@ -117,8 +138,12 @@ export default function ConnectButtons({
         <>
           <span className="text-sm">Connected: {short(address)}</span>
           {onWrongChain && (
-            <button onClick={switchNetwork} className="rounded-xl border px-3 py-1 text-sm">
-              Switch to {CHAIN_ID} (auto)
+            <button
+              onClick={switchNetwork}
+              className="rounded-xl border px-3 py-1 text-sm bg-yellow-50"
+              title={`Switch to ${NETWORK?.name || "Sepolia"}`}
+            >
+              Switch to {NETWORK?.name || "Sepolia"}
             </button>
           )}
         </>
@@ -131,6 +156,7 @@ export default function ConnectButtons({
           {connecting ? "Connecting…" : "Injected (MetaMask/Brave)"}
         </button>
       )}
+      {err && <span className="text-xs text-red-600">{err}</span>}
     </div>
   );
 }

--- a/proofmint-frontend/src/components/ui/Toast.tsx
+++ b/proofmint-frontend/src/components/ui/Toast.tsx
@@ -1,19 +1,49 @@
+// src/components/ui/Toast.tsx
 import { useEffect } from "react";
 
+type Kind = "info" | "success" | "error";
+
 type Props = {
-  kind: "success" | "error";
-  text: string;
+  kind?: Kind;             // default "info"
+  text?: string;           // primary text prop
+  message?: string;        // alias for text (for components that pass `message`)
+  href?: string;           // optional link (e.g., Etherscan)
   onClose?: () => void;
-  durationMs?: number;
+  durationMs?: number;     // default 4500
 };
 
-export default function Toast({ kind, text, onClose, durationMs = 4500 }: Props) {
+export default function Toast({
+  kind = "info",
+  text,
+  message,
+  href,
+  onClose,
+  durationMs = 4500,
+}: Props) {
+  const body = text ?? message ?? "";
+  if (!body) return null;
+
   useEffect(() => {
     const t = setTimeout(() => onClose?.(), durationMs);
     return () => clearTimeout(t);
   }, [onClose, durationMs]);
 
   const base = "fixed top-4 right-4 z-50 px-4 py-3 rounded-xl shadow-lg text-sm";
-  const tone = kind === "success" ? "bg-green-600 text-white" : "bg-red-600 text-white";
-  return <div className={`${base} ${tone}`}>{text}</div>;
+  const tone =
+    kind === "error"   ? "bg-red-600 text-white"   :
+    kind === "success" ? "bg-green-600 text-white" :
+                          "bg-gray-800 text-white"; // info
+
+  return (
+    <div className={`${base} ${tone}`}>
+      {body}
+      {href && (
+        <>
+          {" "}<a className="underline" href={href} target="_blank" rel="noreferrer">
+            Etherscan
+          </a>
+        </>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
**Summary**
Frontend hardening + UX polish:
- Lock Sepolia via `.env.local` and chain guards in `ConnectButtons`
- Owner-only `Withdraw` (checks `Ownable.owner`), opens Etherscan after confirmation
- `BuyForm`: wait 1 conf before linking to Etherscan; improved error copy
- `StatePanel`: zero-safe formatters, auto-refresh (~25s), shows **My balance** when connected
- Unified `Toast` (info/success/error, optional href, auto-dismiss)
- Config moved to `src/config/index.ts`; debug prints gated
- Minor styles (rounded cards, spacing)

**Verification**
- Loads read-only with `FALLBACK_RPC`
- Connect wallet → shows **Switch to Sepolia** if on wrong network
- Buy `0.01` → pending toast → confirmed → Etherscan link opens
- `StatePanel` updates: **Raised** & **Balance** reflect new values; **My balance** shows
- Owner wallet sees **Withdraw**; after withdrawing, **Balance (current)** → `0`, **Raised (lifetime)** stays
- Hard refresh → state still correct via read-only RPC

**Notes**
- Peer-dep warning from `valtio` vs React 19 is benign; can upgrade later.
